### PR TITLE
Add CallerID parse and some unit tests

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: aeb8a368653cbbf086bb89bd9ce53e432e94f944d6601dfbfe825471bfff952d
-updated: 2018-07-23T14:15:51.351419717+02:00
+hash: 46626b9d8ce96c37b94cb1a7d3e1d2b79f44fbc9dc49eef7b53de8cdad1771d8
+updated: 2018-07-26T15:46:55.298534366+02:00
 imports:
 - name: github.com/gammazero/nexus
   version: 81a086cf47177881fa1d0fe47e91ef442fd0bfdc
@@ -16,6 +16,8 @@ imports:
   - wamp/crsign
 - name: github.com/gorilla/websocket
   version: 5ed622c449da6d44c3c8329331ff47a9e5844f71
+- name: github.com/mitchellh/mapstructure
+  version: f15292f7a699fcc1a38a80977f80a046874ba8ac
 - name: github.com/ogier/pflag
   version: 45c278ab3607870051a2ea9040bb85fcb8557481
 - name: github.com/op/go-logging

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,6 +4,7 @@ import:
   version: master
 - package: github.com/op/go-logging
 - package: github.com/gammazero/nexus
-  repo: https://github.com/EmbeddedEnterprises/nexus.git
   version: master
+  repo: https://github.com/EmbeddedEnterprises/nexus.git
   vcs: git
+- package: github.com/mitchellh/mapstructure

--- a/lib.go
+++ b/lib.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gammazero/nexus/client"
 	"github.com/gammazero/nexus/transport/serialize"
 	"github.com/gammazero/nexus/wamp"
+	"github.com/mitchellh/mapstructure"
 	flag "github.com/ogier/pflag"
 	"github.com/op/go-logging"
 )
@@ -665,4 +666,32 @@ func (e *Error) Error() string {
 		return fmt.Sprintf("%s\nInner Error: %s", msg, e.inner.Error())
 	}
 	return msg
+}
+
+// CallerID represents a caller of a wamp RPC invocation
+type CallerID struct {
+	Session  wamp.ID  `mapstructure:"caller"`
+	Username string   `mapstructure:"caller_authid"`
+	Role     []string `mapstructure:"caller_authrole"`
+}
+
+// ParseCallerID extracts caller information from the details dictionary of a wamp RPC invocation
+func ParseCallerID(details wamp.Dict) (*CallerID, error) {
+	c := &CallerID{}
+	if err := mapstructure.WeakDecode(details, c); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+// HasAnyRole checks whether the caller object has any of the specified roles
+func (c *CallerID) HasAnyRole(test []string) bool {
+	for _, r := range c.Role {
+		for _, r2 := range test {
+			if r == r2 {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/lib_test.go
+++ b/lib_test.go
@@ -2,13 +2,99 @@ package service_test
 
 import (
 	"context"
+	"errors"
 	"os"
+	"testing"
 	"time"
 
 	"github.com/EmbeddedEnterprises/service"
 	"github.com/gammazero/nexus/client"
 	"github.com/gammazero/nexus/wamp"
 )
+
+func TestIsRPCError(t *testing.T) {
+	if service.IsRPCError(errors.New("invalid")) {
+		t.Fatal("Expected no RPC error!")
+	}
+
+	if !service.IsRPCError(client.RPCError{}) {
+		t.Fatal("Expected a RPC error!")
+	}
+
+	if service.IsSpecificRPCError(errors.New("invalid"), wamp.ErrNoSuchRealm) {
+		t.Fatal("Expected no 'wamp.ErrNoSuchRealm' error!")
+	}
+
+	if !service.IsSpecificRPCError(client.RPCError{
+		Err: &wamp.Error{
+			Error: wamp.ErrNoSuchRealm,
+		},
+	}, wamp.ErrNoSuchRealm) {
+		t.Fatal("Expected a 'wamp.ErrNoSuchRealm' error!")
+	}
+}
+
+func TestReturnValues(t *testing.T) {
+	empty := service.ReturnEmpty()
+	if len(empty.Args) > 0 || len(empty.Kwargs) > 0 || empty.Err != "" {
+		t.Fatal("Expected empty result!")
+	}
+	singleValue := service.ReturnValue("returnvalue")
+	if len(singleValue.Args) != 1 || singleValue.Args[0] != "returnvalue" {
+		t.Fatal("Expected a single argument 'returnvalue'")
+	}
+	if len(singleValue.Kwargs) > 0 || singleValue.Err != "" {
+		t.Fatal("ReturnValue should not return kwargs or error")
+	}
+	errResult := service.ReturnError("test.error")
+	if len(errResult.Args) > 0 || len(errResult.Kwargs) > 0 || errResult.Err != "test.error" {
+		t.Fatal("ReturnError should return no kwargs or args")
+	}
+}
+
+func TestInvalidParse(t *testing.T) {
+	invalidDict := wamp.Dict{
+		"caller": true,
+		"caller_authid": wamp.Dict{
+			"invalid": "true",
+		},
+	}
+	caller, err := service.ParseCallerID(invalidDict)
+	if err == nil {
+		t.Errorf("Expected error during parse, got caller: %v", caller)
+		return
+	}
+}
+
+func TestCallerIDParse(t *testing.T) {
+	details := wamp.Dict{
+		"caller":        12345,
+		"caller_authid": "foo",
+		"caller_authrole": wamp.List{
+			"trusted",
+			"admin",
+		},
+	}
+	caller, err := service.ParseCallerID(details)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+	if caller.Session != 12345 {
+		t.Errorf("Expected session to be '12345', got: %v", caller.Session)
+	}
+	if caller.Username != "foo" {
+		t.Errorf("Expected caller username to be 'foo', got: %v", caller.Session)
+	}
+	if !caller.HasAnyRole([]string{"trusted"}) {
+		t.Error("Expected caller to have role 'trusted'")
+	}
+	if !caller.HasAnyRole([]string{"admin"}) {
+		t.Error("Expected caller to have role 'admin'")
+	}
+	if caller.HasAnyRole([]string{"foo"}) {
+		t.Error("Expected caller to NOT have role 'foo'")
+	}
+}
 
 func ExampleNew() {
 	srv := service.New(service.Config{


### PR DESCRIPTION
CallerID is a little helper structure used to conveniently identify WAMP callers.
For parsing, mapstructure library is used.

This PR adds tests for `ParseCallerID`, the `service.Return*` functions and `service.Is*RPCError`