### PR TITLE
Introduce a sentinel ping to the server.

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -535,11 +535,14 @@ outer:
 		case <-closePing:
 			break outer
 		case <-ticker.C:
-			if _, err := srv.Client.Call(context.Background(), srv.pingEndpoint, nil, nil, nil, ""); err != nil {
+			ctx, cancel := context.WithTimeout(context.Background(), srv.pingInterval)
+			if _, err := srv.Client.Call(ctx, srv.pingEndpoint, nil, nil, nil, ""); err != nil {
+				cancel()
 				srv.Logger.Criticalf("Ping failed, exiting! %v", err)
 				srv.Client.Close()
 				break outer
 			}
+			cancel()
 		}
 	}
 }


### PR DESCRIPTION
This PR introduces a kind of a watchdog which is required when tunneling parts of an application throgh a reverse proxy or other kinds of firewall which may drops packets without further notice.

The default behavior is to enable ping automatically using the `ee.ping` endpoint provided in autobahnkreuz and a 10 second interval. The user may choose to change the ping endpoint, the interval or whether he wants to enable pings at all.

A `context` is used to ensure timeouts for stale connections are handled correctly.

Tested against kubernetes 1.10 and locally.